### PR TITLE
1 Add proper exclusion to maven shade plugin 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.destroystokyo.paper</groupId>
 			<artifactId>paper</artifactId>
-			<version>1.16.4-R0.1-SNAPSHOT</version>
+			<version>1.16.5-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/github/maxopoly/artemis/listeners/PlayerDataListener.java
+++ b/src/main/java/com/github/maxopoly/artemis/listeners/PlayerDataListener.java
@@ -25,10 +25,10 @@ public class PlayerDataListener implements Listener {
 				ArtemisPlugin.getInstance().getZeus(), ticket, event.getUniqueId());
 		ArtemisPlugin.getInstance().getTransactionIdManager().putSession(session);
 		rabbit.sendMessage(new RequestPlayerData(ticket, event.getUniqueId()));
-		event.setKickMessage(null);
+		event.setKickMessage("");
 		ArtemisPlugin.getInstance().getPlayerDataCache().putWaiting(event.getUniqueId(), event);
 		synchronized (event) {
-			while (event.getKickMessage() == null) {
+			while (event.getKickMessage().equals("")) {
 				try {
 					event.wait();
 				} catch (InterruptedException e) {


### PR DESCRIPTION
In Paper 1.16.5, they have decided to make the leave & kick message NonNullable, I've just swapped it to an empty string in the mean time.